### PR TITLE
Fixed missing word in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,8 +100,8 @@ requirements:
 apt-get install libx11-xcb-dev libxcb-ewmh-dev libpango1.0-dev libcairo2-dev
 ```
 
-If the `volume-widget` is enabled (and it is by default), you will also need
-`alsa-lib`:
+If the `volume-widget` feature is enabled (and it is by default), you will
+also need `alsa-lib`:
 
 ```
 apt-get install libasound2-dev


### PR DESCRIPTION
Hello,

It looks to me like the word "feature" was missing from a sentence in the README.md.
I corrected the sentence while trying to adhere to the 80 char limit, I did this directly on Github's site, hopefully I did it properly

Thanks