### PR TITLE
No such file "current_avg" in sysfs-class-power

### DIFF
--- a/src/widgets/battery.rs
+++ b/src/widgets/battery.rs
@@ -138,7 +138,9 @@ impl Battery {
 
         // If we're discharging, show time to empty.
         // If we're charging, show time to full.
-        let power: f64 = self.load_value("current_avg")?;
+        let power: f64 = self
+            .load_value("current_avg")
+            .or_else(|_| self.load_value("current_now"))?;
         let status: Status = self.load_value("status")?;
         let time = match status {
             Status::Discharging => now / power,


### PR DESCRIPTION
Propose to read current_now when current_avg is missing.

sysfs power info from my laptop:
``` 
$ cat /sys/class/power_supply/BAT0/uevent                                                                                                              POWER_SUPPLY_NAME=BAT0
POWER_SUPPLY_STATUS=Discharging
POWER_SUPPLY_PRESENT=1
POWER_SUPPLY_TECHNOLOGY=Li-poly
POWER_SUPPLY_CYCLE_COUNT=0
POWER_SUPPLY_VOLTAGE_MIN_DESIGN=11400000
POWER_SUPPLY_VOLTAGE_NOW=12600000
POWER_SUPPLY_CURRENT_NOW=756000
POWER_SUPPLY_CHARGE_FULL_DESIGN=4912000
POWER_SUPPLY_CHARGE_FULL=4804000
POWER_SUPPLY_CHARGE_NOW=4723000
POWER_SUPPLY_CAPACITY=98
POWER_SUPPLY_CAPACITY_LEVEL=Normal
POWER_SUPPLY_MODEL_NAME=DELL M7R9677
POWER_SUPPLY_MANUFACTURER=Samsung SDI
POWER_SUPPLY_SERIAL_NUMBER=40738
```