### PR TITLE
Mark hidden desktops

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # v0.3.1
 
- * Add ability to define colors for widgets' attributes with RGB values or Hex color codes.
+* Add ability to define colors for widgets' attributes with RGB values or Hex color codes.
+* Extend pager widget to mark hidden desktops that contain windows.
 
 # v0.3.0
 

--- a/cnx-bin/src/main.rs
+++ b/cnx-bin/src/main.rs
@@ -47,13 +47,6 @@ fn main() -> Result<()> {
         padding: Padding::new(0.0, 0.0, 0.0, 0.0),
     };
 
-    let pager_attr = Attributes {
-        font: Font::new("Ubuntu Mono Bold 14"),
-        fg_color: Color::white(),
-        bg_color: Some(Color::blue()),
-        padding: Padding::new(8.0, 8.0, 0.0, 0.0),
-    };
-
     let mut cnx = Cnx::new(Position::Bottom);
 
     // let sensors = Sensors::new(attr.clone(), vec!["Core 0", "Core 1"]);
@@ -105,15 +98,28 @@ fn main() -> Result<()> {
 
     let weather = weather::Weather::new(attr.clone(), "VOBL".into(), Some(weather_render));
 
+    let active_attr = Attributes {
+        font: Font::new("Ubuntu Mono Bold 14"),
+        fg_color: Color::white(),
+        bg_color: Some(Color::blue()),
+        padding: Padding::new(8.0, 8.0, 0.0, 0.0),
+    };
     let inactive_attr = Attributes {
         bg_color: None,
-        ..pager_attr.clone()
+        ..active_attr.clone()
     };
-    let hidden_attr = Attributes {
+    let non_empty_attr = Attributes {
         fg_color: Color::blue(),
         ..inactive_attr.clone()
     };
-    cnx.add_widget(Pager::new(pager_attr, inactive_attr, hidden_attr));
+    let pager_attrs = PagerAttributes {
+        active_attr,
+        inactive_attr,
+        non_empty_attr,
+    };
+    let pager = Pager::new(pager_attrs);
+
+    cnx.add_widget(pager);
     cnx.add_widget(ActiveWindowTitle::new(attr.clone()));
     cnx.add_widget(cpu);
     cnx.add_widget(weather);

--- a/cnx-bin/src/main.rs
+++ b/cnx-bin/src/main.rs
@@ -105,9 +105,15 @@ fn main() -> Result<()> {
 
     let weather = weather::Weather::new(attr.clone(), "VOBL".into(), Some(weather_render));
 
-    let mut p2_attr = pager_attr.clone();
-    p2_attr.bg_color = None;
-    cnx.add_widget(Pager::new(pager_attr, p2_attr));
+    let inactive_attr = Attributes {
+        bg_color: None,
+        ..pager_attr.clone()
+    };
+    let hidden_attr = Attributes {
+        fg_color: Color::blue(),
+        ..inactive_attr.clone()
+    };
+    cnx.add_widget(Pager::new(pager_attr, inactive_attr, hidden_attr));
     cnx.add_widget(ActiveWindowTitle::new(attr.clone()));
     cnx.add_widget(cpu);
     cnx.add_widget(weather);

--- a/cnx/src/text.rs
+++ b/cnx/src/text.rs
@@ -133,8 +133,11 @@ pub struct Attributes {
 }
 
 pub struct PagerAttributes {
+    /// Active attributes are applied to the currently active workspace
     pub active_attr: Attributes,
+    /// Inactive attributes are applied to workspaces that are not active and contain no windows
     pub inactive_attr: Attributes,
+    /// Non empty attributes are applied to workspaces that are not active and contain windows
     pub non_empty_attr: Attributes,
 }
 

--- a/cnx/src/text.rs
+++ b/cnx/src/text.rs
@@ -132,6 +132,12 @@ pub struct Attributes {
     pub padding: Padding,
 }
 
+pub struct PagerAttributes {
+    pub active_attr: Attributes,
+    pub inactive_attr: Attributes,
+    pub non_empty_attr: Attributes,
+}
+
 fn create_pango_layout(cairo_context: &cairo::Context) -> Result<pango::Layout> {
     let layout = pangocairo::functions::create_layout(cairo_context)
         .ok_or_else(|| anyhow!("Failed to create Pango layout"))?;


### PR DESCRIPTION
This adds a third parameter to the pager widget to distinguish hidden from inactive desktops.
The difference between an inactive and a hidden desktop is that hidden desktops contain windows.