### PR TITLE
Command widget

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 * Add ability to define colors for widgets' attributes with RGB values or Hex color codes.
 * Extend pager widget to mark hidden desktops that contain windows.
 * Fix calculation of cpu usage.
+* Add widget for commands. Shows the output of configured cli commands.
 
 # v0.3.0
 

--- a/cnx-contrib/src/widgets/battery/battery_linux.rs
+++ b/cnx-contrib/src/widgets/battery/battery_linux.rs
@@ -51,7 +51,7 @@ pub struct Battery {
 }
 
 /// Represent Battery information
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct BatteryInfo {
     /// Battery Status
     pub status: Status,

--- a/cnx-contrib/src/widgets/command.rs
+++ b/cnx-contrib/src/widgets/command.rs
@@ -47,14 +47,11 @@ impl Command {
     /// }
     /// fn main() { run().unwrap(); }
     /// ```
-    pub fn new(
-        attr: Attributes,
-        command: String,
-    ) -> Self {
+    pub fn new(attr: Attributes, command: String) -> Self {
         Self { attr, command }
     }
 
-    fn tick(&self) -> Result<Vec<Text>> {
+    fn tick(&self) -> Vec<Text> {
         let output = Process::new("sh")
             .arg("-c")
             .arg(self.command.clone())
@@ -63,11 +60,12 @@ impl Command {
 
         let texts = vec![Text {
             attr: self.attr.clone(),
-            text: String::from_utf8(output.stdout).unwrap_or("error".into()),
+            text: String::from_utf8(output.stdout).unwrap_or_else(|_| "error".into()),
             stretch: false,
             markup: true,
         }];
-        Ok(texts)
+
+        texts
     }
 }
 
@@ -75,7 +73,7 @@ impl Widget for Command {
     fn into_stream(self: Box<Self>) -> Result<WidgetStream> {
         let ten_seconds = Duration::from_secs(10);
         let interval = time::interval(ten_seconds);
-        let stream = IntervalStream::new(interval).map(move |_| self.tick());
+        let stream = IntervalStream::new(interval).map(move |_| Ok(self.tick()));
 
         Ok(Box::pin(stream))
     }

--- a/cnx-contrib/src/widgets/command.rs
+++ b/cnx-contrib/src/widgets/command.rs
@@ -1,0 +1,82 @@
+use anyhow::Result;
+use cnx::text::{Attributes, Text};
+use cnx::widgets::{Widget, WidgetStream};
+use std::process::Command as Process;
+use std::time::Duration;
+use tokio::time;
+use tokio_stream::wrappers::IntervalStream;
+use tokio_stream::StreamExt;
+
+pub struct Command {
+    attr: Attributes,
+    command: String,
+}
+
+impl Command {
+    /// Creates a new [`Command`] widget.
+    ///
+    /// Arguments
+    ///
+    /// * `attr` - Represents `Attributes` which controls properties like
+    /// `Font`, foreground and background color etc.
+    ///
+    /// * `command` - Command to be executed.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// #[macro_use]
+    /// extern crate cnx;
+    ///
+    /// use cnx::*;
+    /// use cnx::text::*;
+    /// use cnx_contrib::widgets::command::*;
+    /// use anyhow::Result;
+    ///
+    /// fn run() -> Result<()> {
+    /// let attr = Attributes {
+    ///     font: Font::new("SourceCodePro 16"),
+    ///     fg_color: Color::white(),
+    ///     bg_color: None,
+    ///     padding: Padding::new(8.0, 8.0, 0.0, 0.0),
+    /// };
+    ///
+    /// let mut cnx = Cnx::new(Position::Top);
+    /// cnx.add_widget(Command::new(attr, "echo foo".into()));
+    /// Ok(())
+    /// }
+    /// fn main() { run().unwrap(); }
+    /// ```
+    pub fn new(
+        attr: Attributes,
+        command: String,
+    ) -> Self {
+        Self { attr, command }
+    }
+
+    fn tick(&self) -> Result<Vec<Text>> {
+        let output = Process::new("sh")
+            .arg("-c")
+            .arg(self.command.clone())
+            .output()
+            .expect("failed to execute process");
+
+        let texts = vec![Text {
+            attr: self.attr.clone(),
+            text: String::from_utf8(output.stdout).unwrap_or("error".into()),
+            stretch: false,
+            markup: true,
+        }];
+        Ok(texts)
+    }
+}
+
+impl Widget for Command {
+    fn into_stream(self: Box<Self>) -> Result<WidgetStream> {
+        let ten_seconds = Duration::from_secs(10);
+        let interval = time::interval(ten_seconds);
+        let stream = IntervalStream::new(interval).map(move |_| self.tick());
+
+        Ok(Box::pin(stream))
+    }
+}

--- a/cnx-contrib/src/widgets/command.rs
+++ b/cnx-contrib/src/widgets/command.rs
@@ -10,6 +10,7 @@ use tokio_stream::StreamExt;
 pub struct Command {
     attr: Attributes,
     command: String,
+    update_interval: Duration,
 }
 
 impl Command {
@@ -22,6 +23,8 @@ impl Command {
     ///
     /// * `command` - Command to be executed.
     ///
+    /// * `update_interval` - Time interval between updates.
+    ///
     /// # Examples
     ///
     /// ```
@@ -32,6 +35,7 @@ impl Command {
     /// use cnx::text::*;
     /// use cnx_contrib::widgets::command::*;
     /// use anyhow::Result;
+    /// use std::time::Duration;
     ///
     /// fn run() -> Result<()> {
     /// let attr = Attributes {
@@ -42,13 +46,17 @@ impl Command {
     /// };
     ///
     /// let mut cnx = Cnx::new(Position::Top);
-    /// cnx.add_widget(Command::new(attr, "echo foo".into()));
+    /// cnx.add_widget(Command::new(attr, "echo foo".into(), Duration::from_secs(10)));
     /// Ok(())
     /// }
     /// fn main() { run().unwrap(); }
     /// ```
-    pub fn new(attr: Attributes, command: String) -> Self {
-        Self { attr, command }
+    pub fn new(attr: Attributes, command: String, update_interval: Duration) -> Self {
+        Self {
+            attr,
+            command,
+            update_interval,
+        }
     }
 
     fn tick(&self) -> Vec<Text> {
@@ -71,8 +79,7 @@ impl Command {
 
 impl Widget for Command {
     fn into_stream(self: Box<Self>) -> Result<WidgetStream> {
-        let ten_seconds = Duration::from_secs(10);
-        let interval = time::interval(ten_seconds);
+        let interval = time::interval(self.update_interval);
         let stream = IntervalStream::new(interval).map(move |_| Ok(self.tick()));
 
         Ok(Box::pin(stream))

--- a/cnx-contrib/src/widgets/mod.rs
+++ b/cnx-contrib/src/widgets/mod.rs
@@ -1,5 +1,7 @@
 /// Battery widget to shows the current capacity
 pub mod battery;
+/// Command widget to show output of a CLI command
+pub mod command;
 /// CPU widget to show the current CPU consumption
 pub mod cpu;
 /// Disk usage widget to show current usage and remaining free space

--- a/cnx/src/text.rs
+++ b/cnx/src/text.rs
@@ -109,7 +109,7 @@ impl Padding {
     }
 }
 
-#[derive(Clone, PartialEq)]
+#[derive(Clone, PartialEq, Eq)]
 pub struct Font(FontDescription);
 
 impl Font {


### PR DESCRIPTION
This adds a new widget `command` to `cnx-contrib`.

It shows the stdout of a configured cli command.

Example for `cnx-bin/src/main.rs`:

```rust
let command = command::Command::new(attr.clone(), "date".into(), Duration::from_secs(10));
cnx.add_widget(command);
```